### PR TITLE
Docker compose support and install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,9 @@ if [ "$EUID" == 0 ]
   exit
 fi
 
+# Get username for regular user.
+USER=$(whoami)
+
 # Start root section
 sudo su root <<'EOF'
 
@@ -29,6 +32,9 @@ systemctl enable docker
 
 # Install Docker Compose
 pip install docker-compose
+
+# Add user to docker group
+usermod -aG docker $USER
 
 # End of root section
 EOF

--- a/install.sh
+++ b/install.sh
@@ -40,5 +40,5 @@ git submodule update --init --recursive
 wget https://github.com/n1nj4sec/pupy/releases/download/latest/payload_templates.txz
 tar xvf payload_templates.txz && mv payload_templates/* pupy/payload_templates/ && rm payload_templates.txz && rm -r payload_templates
 
-# Pull docker container
-docker pull alxchk/pupy:unstable
+# Build docker container
+docker build alxchk/pupy:nodeps

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check to make sure script is not initially run as root
+if [ "$EUID" == 0 ]
+  then echo "Please do not run as root. Script will prompt for sudo password."
+  exit
+fi
+
 # Start root section
 sudo su root <<'EOF'
 

--- a/install.sh
+++ b/install.sh
@@ -41,4 +41,4 @@ wget https://github.com/n1nj4sec/pupy/releases/download/latest/payload_templates
 tar xvf payload_templates.txz && mv payload_templates/* pupy/payload_templates/ && rm payload_templates.txz && rm -r payload_templates
 
 # Build docker container
-docker build -t alxchk/pupy:nodeps -f ./pupy/Dockerfile.compose pupy
+docker build -t alxchk/pupy:base -f ./pupy/Dockerfile.compose pupy

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if running as root, exit if not
+if [ "$EUID" -ne 0 ]
+    then echo "ERROR: The install script must be run as root."
+    exit
+fi
+
 # Apt update and installs
 apt update
 apt install python-pip curl -y

--- a/install.sh
+++ b/install.sh
@@ -40,5 +40,5 @@ git submodule update --init --recursive
 wget https://github.com/n1nj4sec/pupy/releases/download/latest/payload_templates.txz
 tar xvf payload_templates.txz && mv payload_templates/* pupy/payload_templates/ && rm payload_templates.txz && rm -r payload_templates
 
-# Build docker container
-docker build -t alxchk/pupy:nodeps -f ./pupy/Dockerfile.compose pupy
+# Pull docker container
+docker pull alxchk/pupy:unstable

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Apt update and installs
+apt update
+apt install python-pip curl -y
+
+# Install Docker
+curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+
+if [ -f /etc/apt/sources.list.d/docker.list ]; then
+    echo "Apt source entry exists, skipping."
+else
+    echo 'deb https://download.docker.com/linux/debian stretch stable' > /etc/apt/sources.list.d/docker.list
+fi
+
+apt update
+apt-get install docker-ce -y
+systemctl start docker
+systemctl enable docker
+
+# Install Docker Compose
+pip install docker-compose
+
+# Pull dependencies from github
+git submodule update --init --recursive
+
+# Download latest compiled payload templates
+wget https://github.com/n1nj4sec/pupy/releases/download/latest/payload_templates.txz
+tar xvf payload_templates.txz && mv payload_templates/* pupy/payload_templates/ && rm payload_templates.txz && rm -r payload_templates
+
+# Pull docker container
+docker pull alxchk/pupy:unstable

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-# Check if running as root, exit if not
-if [ "$EUID" -ne 0 ]
-    then echo "ERROR: The install script must be run as root."
-    exit
-fi
+# Start root section
+sudo su root <<'EOF'
 
 # Apt update and installs
 apt update
@@ -26,6 +23,9 @@ systemctl enable docker
 
 # Install Docker Compose
 pip install docker-compose
+
+# End of root section
+EOF
 
 # Pull dependencies from github
 git submodule update --init --recursive

--- a/install.sh
+++ b/install.sh
@@ -40,5 +40,5 @@ git submodule update --init --recursive
 wget https://github.com/n1nj4sec/pupy/releases/download/latest/payload_templates.txz
 tar xvf payload_templates.txz && mv payload_templates/* pupy/payload_templates/ && rm payload_templates.txz && rm -r payload_templates
 
-# Pull docker container
-docker pull alxchk/pupy:unstable
+# Build docker container
+docker build -t alxchk/pupy:nodeps -f ./pupy/Dockerfile.compose pupy

--- a/install.sh
+++ b/install.sh
@@ -41,4 +41,4 @@ wget https://github.com/n1nj4sec/pupy/releases/download/latest/payload_templates
 tar xvf payload_templates.txz && mv payload_templates/* pupy/payload_templates/ && rm payload_templates.txz && rm -r payload_templates
 
 # Build docker container
-docker build alxchk/pupy:nodeps
+docker build -t alxchk/pupy:nodeps -f ./pupy/Dockerfile.compose pupy

--- a/install.sh
+++ b/install.sh
@@ -47,4 +47,4 @@ wget https://github.com/n1nj4sec/pupy/releases/download/latest/payload_templates
 tar xvf payload_templates.txz && mv payload_templates/* pupy/payload_templates/ && rm payload_templates.txz && rm -r payload_templates
 
 # Build docker container
-docker build -t alxchk/pupy:base -f ./pupy/Dockerfile.compose pupy
+sudo docker build -t alxchk/pupy:base -f ./pupy/Dockerfile.compose pupy

--- a/pupy/Dockerfile.compose
+++ b/pupy/Dockerfile.compose
@@ -1,0 +1,44 @@
+FROM debian:stretch-slim
+
+LABEL maintainer "alxchk@gmail.com"
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo 'deb http://ftp.debian.org/debian stretch-backports main' >>/etc/apt/sources.list && \
+    apt-get update && \
+    mkdir -p /usr/share/man/man1/ && \
+    apt-get install -t stretch-backports --no-install-recommends -y build-essential libssl1.0-dev libffi-dev \
+    python-dev python-pip tmux sslh libcap2-bin \
+    john vim-tiny less osslsigncode nmap net-tools \
+    autoconf automake unzip libtool locales ncurses-term bash tcpdump libpam-cap \
+    openjdk-8-jdk-headless netbase \
+    git fuse && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /usr/share/doc* /usr/share/man/* /usr/share/info/*
+RUN echo 'en_US.UTF-8 UTF-8' >/etc/locale.gen; locale-gen; echo 'LC_ALL=en_US.UTF-8' >/etc/default/locale
+
+COPY conf/capability.conf /etc/security/capability.conf
+
+RUN chmod +s /usr/sbin/tcpdump
+
+RUN python -m pip install --upgrade pip six setuptools wheel
+
+COPY ./requirements.txt /opt/requirements.txt
+COPY ./external /opt/external
+RUN cd /opt && pip install --upgrade -r requirements.txt
+
+ADD https://github.com/gentilkiwi/mimikatz/releases/download/2.1.1-20180817/mimikatz_trunk.zip \
+    /opt/mimikatz/mimikatz.zip
+RUN cd /opt/mimikatz && unzip mimikatz.zip && rm -f mimikatz.zip
+RUN mkdir /opt/uacme
+RUN apt-get remove -y autoconf automake python-dev libtool build-essential && \
+    apt-get -y autoremove && rm -rf /root/.cache/pip && \
+    rm -f /tmp/requirements.txt
+
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+EXPOSE 1080 5454 5454/udp 8080
+#VOLUME [ "/projects" ]
+
+WORKDIR /opt/pupy
+ENTRYPOINT [ "./pupysh.py" ]

--- a/pupy/Dockerfile.compose
+++ b/pupy/Dockerfile.compose
@@ -15,7 +15,7 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main' >>/etc/apt/so
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/doc* /usr/share/man/* /usr/share/info/*
 RUN echo 'en_US.UTF-8 UTF-8' >/etc/locale.gen; locale-gen; echo 'LC_ALL=en_US.UTF-8' >/etc/default/locale
-RUN useradd -m -d /home/pupy
+RUN useradd -m -d /home/pupy pupy
 
 COPY conf/capability.conf /etc/security/capability.conf
 

--- a/pupy/Dockerfile.compose
+++ b/pupy/Dockerfile.compose
@@ -43,4 +43,3 @@ EXPOSE 1080 5454 5454/udp 8080
 
 WORKDIR /opt/pupy
 ENTRYPOINT [ "./pupysh.py" ]
-CMD [ "--not-encrypt" ]

--- a/pupy/Dockerfile.compose
+++ b/pupy/Dockerfile.compose
@@ -15,10 +15,12 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main' >>/etc/apt/so
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/doc* /usr/share/man/* /usr/share/info/*
 RUN echo 'en_US.UTF-8 UTF-8' >/etc/locale.gen; locale-gen; echo 'LC_ALL=en_US.UTF-8' >/etc/default/locale
+RUN useradd -m -d /home/pupy
 
 COPY conf/capability.conf /etc/security/capability.conf
 
 RUN chmod +s /usr/sbin/tcpdump
+RUN chown pupy:pupy -R /home/pupy
 
 RUN python -m pip install --upgrade pip six setuptools wheel
 
@@ -38,7 +40,6 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 EXPOSE 1080 5454 5454/udp 8080
-#VOLUME [ "/projects" ]
 
 WORKDIR /opt/pupy
 ENTRYPOINT [ "./pupysh.py" ]

--- a/pupy/Dockerfile.compose
+++ b/pupy/Dockerfile.compose
@@ -43,3 +43,4 @@ EXPOSE 1080 5454 5454/udp 8080
 
 WORKDIR /opt/pupy
 ENTRYPOINT [ "./pupysh.py" ]
+CMD [ "--not-encrypt" ]

--- a/pupy/docker-compose.yml
+++ b/pupy/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   pupy:
-    image: alxchk/pupy:unstable
+    image: alxchk/pupy:nodeps
     user: pupy
     volumes:
       - .:/opt/pupy

--- a/pupy/docker-compose.yml
+++ b/pupy/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   pupy:
     image: alxchk/pupy:unstable
+    user: pupy
     volumes:
       - .:/opt/pupy
     ports:

--- a/pupy/docker-compose.yml
+++ b/pupy/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  pupy:
+    image: alxchk/pupy:unstable
+    volumes:
+      - .:/opt/pupy
+    ports:
+      - 8443:8443
+    container_name: pupy
+    stdin_open: true
+    tty: true

--- a/pupy/docker-compose.yml
+++ b/pupy/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   pupy:
-    image: alxchk/pupy:nodeps
+    image: alxchk/pupy:base
     user: pupy
     volumes:
       - .:/opt/pupy

--- a/pupy/pupy.conf
+++ b/pupy/pupy.conf
@@ -1,0 +1,159 @@
+[pupyd]
+#listen on all interfaces by default
+# address = 192.168.0.1
+
+## Default external address for all transports
+# external = 1.2.3.4
+
+transport = ssl
+ipv6 = true
+logs = false
+webserver = false
+
+#Multiple listeners are allowed. Example
+#listen = ssl,kc4,websocket
+listen = ssl
+
+#igd=True allow pupy to make IGD/UPNP requests to get you external IP and
+#    add mappings to your local machine from outside
+#If enabled, pupy will implicitly expect that pupysh sits behind NAT
+#igd = http://ip[:port] will disable autodetect
+igd = false
+
+#httpd=true wraps your transport in a HTTP transport.
+httpd = false
+
+#dnscnc = localhost:5454 starts the DNS cnc listener on the port 5454.
+dnscnc = false
+recursor = false
+
+# allow requests to services like ifconfig.co to automatically retrieve public IP
+# you should enable this if you planning to use IGD/UPNP
+allow_requests_to_external_services = false
+
+use_gnome_keyring=false
+
+ping = 0
+ping_timeout = 10
+
+# Enable modules which are marked as QA_DANGEROUS
+# These modules may cause the pupy hang or require manual changes
+enable_dangerous_modules = false
+
+# Prohibit communication of unregistered cid <-> node pairs
+whitelist = false
+# ... only if cid found in config ([cids])
+# format:
+# cid = node1,node2,node3
+allow_by_default = true
+
+[dnscnc]
+# Allow DNSCNC v1 (legacy)
+allow_v1 = true
+# Prohibit communication of unregistered cid <-> node pairs
+whitelist = false
+# ... only if cid found in config ([cids])
+# format:
+# cid = node1,node2,node3
+allow_by_default = true
+
+# Whitelist (if enabled)
+[cids]
+
+[listeners]
+# Default ports and args
+# Ensure ports are different for all enabled listeners
+# Or remove listener(s) from pupyd.listen parameter
+ssl = 8443
+obfs3 = 9090
+rsa = 9091
+ec4 = 80=1234
+kc4 = 123=1234
+tcp_cleartext = 80=1234
+udp_cleartext = 123=1234
+websocket = 80=8081
+http = 80=8080
+ecm = 1235
+
+[ssl]
+client_cert_required = true
+
+[httpd]
+log = true
+secret = false
+
+[gen]
+format = client
+os = windows
+arch = x86
+external = false
+#The command used for packing the 'client' output format (incompatible with py, pyinst, py_oneliner, ps1, ps1_oneliner, rubber_ducky for example)
+packer = 
+#launcher =
+#launcher_args = 
+
+[cmdline]
+display_banner = yes
+colors = yes
+
+[paths]
+prefer_workdir = no
+downloads = data/downloads/%c
+memstrings = data/memstrings/%c
+searches = data/searches/%c
+screenshots = data/screenshots/%c/%t
+pcaps = data/pcaps/%c/%t.pcap
+logs = data/logs/%c/%t-%M
+creds = data/creds
+crypto = crypto
+wwwroot = data/wwwroot
+records = data/%c
+keystrokes = data/keylogger/%c/%t.log
+mouseshots = data/mouselogger/%c/%w-%t.png
+payload_output = output
+
+[on_connect]
+
+## FORMAT:
+## FILTER = ACTION
+## FILTER: [SPI|NODE|*...|any...|client_filter]
+##   Use '*' and 'any' prefix to apply action to all clients
+##   Use SPI or NODE to apply action only to clients with same SPI/NODE id
+##   Other values will be used as client_filter argument (like run -f)
+## ACTION: [!...|include:section_name|module args|]
+##   Use '!' prefix to execute shell command
+##   Use 'include:' prefix to include commands with specified section name
+
+## Example: include actions in section on_connect_notifications
+# any = include:on_connect_notifications
+
+[on_connect_notifications]
+any1 = !notify-send "New session: {hostname} / {os_name}"
+
+[default_viewers]
+image_viewer = eog
+sound_player = totem
+browser = firefox
+
+[mimikatz]
+#these are kali 2.0 default path
+exe_Win32=/usr/share/mimikatz/Win32/mimikatz.exe
+exe_x64=/usr/share/mimikatz/x64/mimikatz.exe
+
+[aliases]
+info = get_info
+pyexec = pyexec
+exec = shell_exec
+ps = ps
+migrate = migrate
+shell=interactive_shell
+kill = process_kill
+#tasklist = shell_exec 'tasklist /v'
+mount = drives
+du = download -S
+
+[rubber_ducky]
+#path to the encoder.jar file of Rubber-Ducky project (see https://github.com/hak5darren/USB-Rubber-Ducky/blob/master/Encoder/encoder.jar)
+encoder_path = TO_FILL
+#Path to the keyboard layout for generating inject.bin file (see https://github.com/hak5darren/USB-Rubber-Ducky/tree/master/Encoder/resources)
+default_keyboard_layout_path = TO_FILL

--- a/pupy/pupy_start_compose.sh
+++ b/pupy/pupy_start_compose.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose up -d && docker attach pupy


### PR DESCRIPTION
I have implemented docker compose support. Pupy now has a single script that will install docker and docker compose on a Debian 9 system (Kali is not tested). It pulls the compiled payload templates from releases. It will also build a "base" docker image that includes only the dependencies of pupy, but not the installation itself. This is to avoid redundancy, as the pupy directory is mounted directly in the image anyway, rather than copied over during the build.

No existing files have been modified in any way, and it is possible to use both methods (compose and the regular image) for deploying pupy if the user should wish to.

To completely configure the environment, simply run `./install.sh` as a regular user (it will prompt for sudo password). After that, starting pupy via compose is as simple as `./pupy_start_compose.sh` in the pupy subdirectory.

@alxchk: You may want to include the base image in the automated docker build process. If you do, remember to edit the last line of install.sh to pull from the repo rather than build. I have reduced the base version to 863MB.