### PR TITLE
Change install.sh not to use reserved shell variables for username during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ if [ "$EUID" == 0 ]
 fi
 
 # Get username for regular user.
-USER=$(whoami)
+username=$(whoami)
 
 # Start root section
 sudo su root <<'EOF'
@@ -34,7 +34,7 @@ systemctl enable docker
 pip install docker-compose
 
 # Add user to docker group
-usermod -aG docker $USER
+usermod -aG docker $username
 
 # End of root section
 EOF


### PR DESCRIPTION
Previously, I used the $USER variable to set the user's group using usermod. This is a reserved shell variable, which lead to the root user being added to the docker group instead of the regular user. This commit fixes that by changing the variable name.